### PR TITLE
Fix integer calculation for EASE_LINEAR.

### DIFF
--- a/src/ServoEasing.cpp
+++ b/src/ServoEasing.cpp
@@ -797,7 +797,7 @@ bool ServoEasing::update() {
          * 40 us to compute
          */
         tNewMicrosecondsOrUnits = mStartMicrosecondsOrUnits
-                + ((mDeltaMicrosecondsOrUnits * (int32_t) tMillisSinceStart) / mMillisForCompleteMove);
+                + ((mDeltaMicrosecondsOrUnits * (int32_t) tMillisSinceStart) / (int32_t) mMillisForCompleteMove);
     } else {
         /*
          * Non linear movement -> use floats


### PR DESCRIPTION
In the marked line, the numerator is promoted to unsigned. When delta is negative, the servo runs through a bunch of invalid states, then snaps to final position.