### PR TITLE
Add dependency for ESP32 device

### DIFF
--- a/library.json
+++ b/library.json
@@ -23,5 +23,13 @@
     "espressif32",
     "ststm32"
   ],
-  "headers": "ServoEasing.hpp"
+  "headers": "ServoEasing.hpp",
+  "dependencies": [
+    {
+      "owner": "madhephaestus",
+      "name": "ESP32Servo",
+      "version": "*",
+      "platforms": ["espressif32"]
+    }
+  ]
 }


### PR DESCRIPTION
Hello,

A small modification to automatically install the ESPServo library with PlatformIO with ESP32 device. 